### PR TITLE
[Quickplay] Remove Pixel Party hyper mode

### DIFF
--- a/hypixel/quickplay-data.json
+++ b/hypixel/quickplay-data.json
@@ -394,11 +394,7 @@
       },
       {
         "key": "ARCADE_PIXEL_PARTY",
-        "name": "Pixel Party - Normal Mode"
-      },
-      {
-        "key": "ARCADE_PIXEL_PARTY_HYPER",
-        "name": "Pixel Party - Hyper Mode"
+        "name": "Pixel Party"
       },
       {
         "key": "ARCADE_DROPPER",


### PR DESCRIPTION
This change removes the Pixel Party hyper mode command from quickplay as the two modes have been merged into one queue.